### PR TITLE
Pin the version of nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,13 @@
-with (import <nixpkgs>) {};
-(python27.withPackages (ps: [
-    ps.whoosh
-    ps.wxPython
-])).env
+let
+     pkgs = import (builtins.fetchGit {
+         name = "python2-7-17";                                                 
+         url = "https://github.com/NixOS/nixpkgs/";                       
+         ref = "refs/heads/nixpkgs-unstable";                     
+         rev = "2d9888f61c80f28b09d64f5e39d0ba02e3923057";                                           
+     }) {};                                                                           
+     python27 = pkgs.python27Full;
+in
+    (python27.withPackages (ps: [
+        ps.whoosh
+        ps.wxPython
+    ])).env


### PR DESCRIPTION
With a freshly-installed nix I ran into this issue:

    ; nix-shell
    error: Package ‘python-2.7.18.6-env’ in /nix/store/arj2cbiypb90whh8ai3m68q49dijy688-nixpkgs/nixpkgs/pkgs/development/interpreters/python/cpython/2.7/default.nix:330 is marked as insecure, refusing to evaluate.
    ...

Following the instructions (of allowing insecure packages) I ended up with the next issue:

    ; nix-shell

    ...

    error: attribute 'wxPython' missing

           at /home/bheesham/dev/notes-app/shell.nix:4:5:

                3|     ps.whoosh
                4|     ps.wxPython
                 |     ^
                5| ])).env
    (use '--show-trace' to show detailed location information)

This commit pins a version of nixpkgs where:

* the Python version is 2.7.17;
* wxPython is available; and
* we don't need to allow insecure packages (though this benefit is debatable).